### PR TITLE
Add nearest target selection via Tab key

### DIFF
--- a/Aura.uproject
+++ b/Aura.uproject
@@ -3,13 +3,20 @@
 	"EngineAssociation": "5.4",
 	"Category": "",
 	"Description": "",
-	"Plugins": [
-		{
-			"Name": "ModelingToolsEditorMode",
-			"Enabled": true,
-			"TargetAllowList": [
-				"Editor"
-			]
-		}
-	]
+        "Modules": [
+                {
+                        "Name": "Aura",
+                        "Type": "Runtime",
+                        "LoadingPhase": "Default"
+                }
+        ],
+        "Plugins": [
+                {
+                        "Name": "ModelingToolsEditorMode",
+                        "Enabled": true,
+                        "TargetAllowList": [
+                                "Editor"
+                        ]
+                }
+        ]
 }

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -3,6 +3,7 @@
 [/Script/EngineSettings.GameMapsSettings]
 GameDefaultMap=/Game/Maps/StartupMap.StartupMap
 EditorStartupMap=/Game/Maps/StartupMap.StartupMap
+GlobalDefaultGameMode="/Script/Aura.AuraGameMode"
 
 [/Script/WindowsTargetPlatform.WindowsTargetSettings]
 DefaultGraphicsRHI=DefaultGraphicsRHI_DX12

--- a/Source/Aura/Aura.Build.cs
+++ b/Source/Aura/Aura.Build.cs
@@ -1,0 +1,17 @@
+using UnrealBuildTool;
+
+public class Aura : ModuleRules
+{
+    public Aura(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new string[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "InputCore"
+        });
+    }
+}

--- a/Source/Aura/Private/AuraGameMode.cpp
+++ b/Source/Aura/Private/AuraGameMode.cpp
@@ -1,0 +1,7 @@
+#include "AuraGameMode.h"
+#include "AuraPlayerController.h"
+
+AAuraGameMode::AAuraGameMode()
+{
+    PlayerControllerClass = AAuraPlayerController::StaticClass();
+}

--- a/Source/Aura/Private/AuraPlayerController.cpp
+++ b/Source/Aura/Private/AuraPlayerController.cpp
@@ -1,0 +1,24 @@
+#include "AuraPlayerController.h"
+#include "TargetingLibrary.h"
+#include "InputCoreTypes.h"
+
+AAuraPlayerController::AAuraPlayerController()
+{
+    CurrentTarget = nullptr;
+}
+
+void AAuraPlayerController::SetupInputComponent()
+{
+    Super::SetupInputComponent();
+
+    if (InputComponent)
+    {
+        InputComponent->BindKey(EKeys::Tab, IE_Pressed, this, &AAuraPlayerController::SelectNearestTarget);
+    }
+}
+
+void AAuraPlayerController::SelectNearestTarget()
+{
+    AActor* Requestor = GetPawn() ? GetPawn() : Cast<AActor>(this);
+    CurrentTarget = UTargetingLibrary::GetNearestTarget(Requestor, TargetClass);
+}

--- a/Source/Aura/Private/TargetingLibrary.cpp
+++ b/Source/Aura/Private/TargetingLibrary.cpp
@@ -1,0 +1,37 @@
+#include "TargetingLibrary.h"
+#include "Kismet/GameplayStatics.h"
+#include <cfloat>
+
+AActor* UTargetingLibrary::GetNearestTarget(AActor* Requestor, TSubclassOf<AActor> TargetClass)
+{
+    if (!Requestor || !TargetClass)
+    {
+        return nullptr;
+    }
+
+    UWorld* World = Requestor->GetWorld();
+    if (!World)
+    {
+        return nullptr;
+    }
+
+    TArray<AActor*> FoundActors;
+    UGameplayStatics::GetAllActorsOfClass(World, TargetClass, FoundActors);
+
+    AActor* ClosestActor = nullptr;
+    float MinDistSq = FLT_MAX;
+
+    const FVector RequestorLocation = Requestor->GetActorLocation();
+
+    for (AActor* Actor : FoundActors)
+    {
+        const float DistSq = FVector::DistSquared(RequestorLocation, Actor->GetActorLocation());
+        if (DistSq < MinDistSq)
+        {
+            MinDistSq = DistSq;
+            ClosestActor = Actor;
+        }
+    }
+
+    return ClosestActor;
+}

--- a/Source/Aura/Public/AuraGameMode.h
+++ b/Source/Aura/Public/AuraGameMode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "GameFramework/GameModeBase.h"
+#include "AuraGameMode.generated.h"
+
+/**\n * Game mode that uses AAuraPlayerController by default.\n */
+UCLASS()
+class AURA_API AAuraGameMode : public AGameModeBase
+{
+    GENERATED_BODY()
+public:
+    AAuraGameMode();
+};

--- a/Source/Aura/Public/AuraPlayerController.h
+++ b/Source/Aura/Public/AuraPlayerController.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "GameFramework/PlayerController.h"
+#include "AuraPlayerController.generated.h"
+
+/**
+ * PlayerController that selects the nearest target when TAB is pressed.
+ */
+UCLASS()
+class AURA_API AAuraPlayerController : public APlayerController
+{
+    GENERATED_BODY()
+
+public:
+    AAuraPlayerController();
+
+    virtual void SetupInputComponent() override;
+
+    /** Class of actors considered as valid targets */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Targeting")
+    TSubclassOf<AActor> TargetClass;
+
+    /** Currently selected target */
+    UPROPERTY(BlueprintReadOnly, Category="Targeting")
+    AActor* CurrentTarget;
+
+    /** Finds the nearest target and stores it in CurrentTarget */
+    UFUNCTION(BlueprintCallable, Category="Targeting")
+    void SelectNearestTarget();
+};

--- a/Source/Aura/Public/TargetingLibrary.h
+++ b/Source/Aura/Public/TargetingLibrary.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "TargetingLibrary.generated.h"
+
+UCLASS()
+class AURA_API UTargetingLibrary : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintPure, Category="Targeting")
+    static AActor* GetNearestTarget(AActor* Requestor, TSubclassOf<AActor> TargetClass);
+};


### PR DESCRIPTION
## Summary
- configure default game mode to use a custom Aura player controller
- implement `AAuraPlayerController` that binds TAB to choosing the nearest target
- expose `AAuraGameMode` setting the player controller class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409df5ddc88325a019ac90d4437f72