### PR TITLE
Add Aura C++ module with gameplay attribute set

### DIFF
--- a/Aura.uproject
+++ b/Aura.uproject
@@ -1,15 +1,22 @@
 {
-	"FileVersion": 3,
-	"EngineAssociation": "5.4",
-	"Category": "",
-	"Description": "",
-	"Plugins": [
-		{
-			"Name": "ModelingToolsEditorMode",
-			"Enabled": true,
-			"TargetAllowList": [
-				"Editor"
-			]
-		}
-	]
+    "FileVersion": 3,
+    "EngineAssociation": "5.4",
+    "Category": "",
+    "Description": "",
+    "Modules": [
+        {
+            "Name": "Aura",
+            "Type": "Runtime",
+            "LoadingPhase": "Default"
+        }
+    ],
+    "Plugins": [
+        {
+            "Name": "ModelingToolsEditorMode",
+            "Enabled": true,
+            "TargetAllowList": [
+                "Editor"
+            ]
+        }
+    ]
 }

--- a/Source/Aura.Target.cs
+++ b/Source/Aura.Target.cs
@@ -1,0 +1,15 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class AuraTarget : TargetRules
+{
+    public AuraTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Game;
+        DefaultBuildSettings = BuildSettingsVersion.V2;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+        ExtraModuleNames.Add("Aura");
+    }
+}

--- a/Source/Aura/Aura.Build.cs
+++ b/Source/Aura/Aura.Build.cs
@@ -1,0 +1,22 @@
+using UnrealBuildTool;
+
+public class Aura : ModuleRules
+{
+    public Aura(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new string[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "InputCore",
+            "GameplayAbilities",
+            "GameplayTags",
+            "GameplayTasks"
+        });
+
+        PrivateDependencyModuleNames.AddRange(new string[] { });
+    }
+}

--- a/Source/Aura/Aura.cpp
+++ b/Source/Aura/Aura.cpp
@@ -1,0 +1,6 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, Aura, "Aura");

--- a/Source/Aura/Private/AS_CharacterAttributes.cpp
+++ b/Source/Aura/Private/AS_CharacterAttributes.cpp
@@ -1,0 +1,34 @@
+#include "AS_CharacterAttributes.h"
+#include "Net/UnrealNetwork.h"
+
+UAS_CharacterAttributes::UAS_CharacterAttributes()
+{
+    // Set some sensible defaults so designers have values to work with immediately.
+    MaxHealth = 100.0f;
+    Health = MaxHealth;
+    Mana = 100.0f;
+}
+
+void UAS_CharacterAttributes::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME_CONDITION_NOTIFY(UAS_CharacterAttributes, Health, COND_None, REPNOTIFY_Always);
+    DOREPLIFETIME_CONDITION_NOTIFY(UAS_CharacterAttributes, MaxHealth, COND_None, REPNOTIFY_Always);
+    DOREPLIFETIME_CONDITION_NOTIFY(UAS_CharacterAttributes, Mana, COND_None, REPNOTIFY_Always);
+}
+
+void UAS_CharacterAttributes::OnRep_Health(const FGameplayAttributeData& OldHealth)
+{
+    GAMEPLAYATTRIBUTE_REPNOTIFY(UAS_CharacterAttributes, Health, OldHealth);
+}
+
+void UAS_CharacterAttributes::OnRep_MaxHealth(const FGameplayAttributeData& OldMaxHealth)
+{
+    GAMEPLAYATTRIBUTE_REPNOTIFY(UAS_CharacterAttributes, MaxHealth, OldMaxHealth);
+}
+
+void UAS_CharacterAttributes::OnRep_Mana(const FGameplayAttributeData& OldMana)
+{
+    GAMEPLAYATTRIBUTE_REPNOTIFY(UAS_CharacterAttributes, Mana, OldMana);
+}

--- a/Source/Aura/Public/AS_CharacterAttributes.h
+++ b/Source/Aura/Public/AS_CharacterAttributes.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AttributeSet.h"
+#include "AbilitySystemComponent.h"
+#include "AS_CharacterAttributes.generated.h"
+
+// Macro util ca să nu scrii de 100 de ori aceleași funcții
+#define ATTRIBUTE_ACCESSORS(ClassName, PropertyName) \
+GAMEPLAYATTRIBUTE_PROPERTY_GETTER(ClassName, PropertyName) \
+GAMEPLAYATTRIBUTE_VALUE_GETTER(PropertyName) \
+GAMEPLAYATTRIBUTE_VALUE_SETTER(PropertyName) \
+GAMEPLAYATTRIBUTE_VALUE_INITTER(PropertyName)
+
+UCLASS()
+class AURA_API UAS_CharacterAttributes : public UAttributeSet
+{
+    GENERATED_BODY()
+
+public:
+    UAS_CharacterAttributes();
+
+    // HEALTH
+    UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_Health)
+    FGameplayAttributeData Health;
+    ATTRIBUTE_ACCESSORS(UAS_CharacterAttributes, Health);
+
+    UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_MaxHealth)
+    FGameplayAttributeData MaxHealth;
+    ATTRIBUTE_ACCESSORS(UAS_CharacterAttributes, MaxHealth);
+
+    // MANA (exemplu, poți adăuga ce vrei)
+    UPROPERTY(BlueprintReadOnly, Category = "Attributes", ReplicatedUsing = OnRep_Mana)
+    FGameplayAttributeData Mana;
+    ATTRIBUTE_ACCESSORS(UAS_CharacterAttributes, Mana);
+
+protected:
+    UFUNCTION()
+    void OnRep_Health(const FGameplayAttributeData& OldHealth);
+
+    UFUNCTION()
+    void OnRep_MaxHealth(const FGameplayAttributeData& OldMaxHealth);
+
+    UFUNCTION()
+    void OnRep_Mana(const FGameplayAttributeData& OldMana);
+
+public:
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+};

--- a/Source/AuraEditor.Target.cs
+++ b/Source/AuraEditor.Target.cs
@@ -1,0 +1,15 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class AuraEditorTarget : TargetRules
+{
+    public AuraEditorTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Editor;
+        DefaultBuildSettings = BuildSettingsVersion.V2;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+        ExtraModuleNames.Add("Aura");
+    }
+}


### PR DESCRIPTION
## Summary
- add Aura C++ module scaffolding and build targets for the project
- introduce a Gameplay Ability System attribute set for health and mana with replication helpers

## Testing
- not run (Unreal build environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925688343348325b32ad500d802ee89)